### PR TITLE
feat: Change default port to 3333

### DIFF
--- a/weather_mcp/Dockerfile
+++ b/weather_mcp/Dockerfile
@@ -16,15 +16,15 @@ COPY . .
 ENV MCP_TRANSPORT_MODE=streamable-http
 ENV DEFAULT_CITY=Beijing,cn
 ENV HTTP_HOST=0.0.0.0
-ENV HTTP_PORT=8000
+ENV HTTP_PORT=3333
 ENV SSE_HOST=0.0.0.0
-ENV SSE_PORT=8000
+ENV SSE_PORT=3333
 ENV LOG_LEVEL=INFO
 
 # Add Docker health check using the MCP health_check tool
 # Check every 30 seconds, with 3s timeout, start checking after 10s, and fail after 3 retries
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD curl -f http://localhost:8000/mcp/info || exit 1
+  CMD curl -f http://localhost:3333/mcp/info || exit 1
 
 # Run the server using Python directly
 CMD ["python3", "main.py"]

--- a/weather_mcp/README.md
+++ b/weather_mcp/README.md
@@ -109,7 +109,7 @@ fastmcp run main.py:mcp
 For HTTP streaming mode:
 ```bash
 # If fastmcp is installed as a command-line tool
-fastmcp run main.py:mcp --transport sse --host 127.0.0.1 --port 8000
+fastmcp run main.py:mcp --transport sse --host 127.0.0.1 --port 3333
 ```
 
 Alternatively, you can set `mode: sse` in `config.yaml` and run with Python directly.
@@ -132,7 +132,7 @@ docker-compose down
 ```
 
 **Health Check:**
-The Docker configurations (`Dockerfile` and `docker-compose.yml`) define a health check to monitor the server's status. This health check now utilizes a GET request to the `/mcp/info` endpoint (accessible at `http://localhost:8000/mcp/info` if the container's port 8000 is mapped to the host's port 8000). This endpoint returns a JSON response confirming the service is operational.
+The Docker configurations (`Dockerfile` and `docker-compose.yml`) define a health check to monitor the server's status. This health check now utilizes a GET request to the `/mcp/info` endpoint (accessible at `http://localhost:3333/mcp/info` if the container's port 3333 is mapped to the host's port 3333). This endpoint returns a JSON response confirming the service is operational.
 
 #### Using Docker directly:
 
@@ -151,7 +151,7 @@ docker run -d --name weather-mcp-server \
   -e MCP_TRANSPORT_MODE=sse \
   -e HTTP_HOST=0.0.0.0 \
   -e SSE_HOST=0.0.0.0 \
-  -p 8000:8000 \
+  -p 3333:3333 \
   weather-mcp-server
 ```
 
@@ -252,7 +252,7 @@ To connect to the HTTP streaming server:
 1. Establish a streaming connection:
    ```javascript
    // Browser example
-   const eventSource = new EventSource('http://localhost:8000/stream');
+   const eventSource = new EventSource('http://localhost:3333/stream');
    eventSource.onmessage = (event) => {
      const data = JSON.parse(event.data);
      console.log('Received:', data);
@@ -263,7 +263,7 @@ To connect to the HTTP streaming server:
    ```javascript
    // Browser example
    const clientId = '...'; // Get this from the streaming connection headers
-   fetch('http://localhost:8000/mcp', {
+   fetch('http://localhost:3333/mcp', {
      method: 'POST',
      headers: {
        'Content-Type': 'application/json',

--- a/weather_mcp/config.yaml.example
+++ b/weather_mcp/config.yaml.example
@@ -8,6 +8,7 @@ apikey: your api key
 #   - sse: HTTP server mode with streaming support (recommended for web clients)
 #   - streamable-http: Alias for sse mode (for backward compatibility)
 mode: sse
+port: 3333
 
 # Default city to use when no city is specified in requests
 # Format: City name, optionally with country code (e.g., "London,uk")

--- a/weather_mcp/main.py
+++ b/weather_mcp/main.py
@@ -192,14 +192,14 @@ if __name__ == "__main__":
         if mode == 'sse':
             # Get host and port from environment or use defaults
             host = os.getenv('HTTP_HOST', os.getenv('SSE_HOST', '127.0.0.1'))
-            port = int(os.getenv('HTTP_PORT', os.getenv('SSE_PORT', '8000')))
+            port = int(os.getenv('HTTP_PORT', os.getenv('SSE_PORT', '3333')))
             
             logger.info(f"Starting server with SSE transport at http://{host}:{port}")
             mcp.run(transport="sse", host=host, port=port)
         elif mode == 'streamable-http':
             # Get host and port from environment or use defaults
             host = os.getenv('HTTP_HOST', '127.0.0.1')
-            port = int(os.getenv('HTTP_PORT', '8000'))
+            port = int(os.getenv('HTTP_PORT', '3333'))
             path = os.getenv('HTTP_PATH', '/mcp')
             
             logger.info(f"Starting server with streamable-http transport at http://{host}:{port}{path}")

--- a/weather_mcp/run_server.sh
+++ b/weather_mcp/run_server.sh
@@ -20,7 +20,7 @@ show_help() {
 # Default values
 MODE="streamable-http"
 HOST="127.0.0.1"
-PORT="8000"
+PORT="3333"
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
This commit changes the default server port from 8000 to 3333 for all applicable modes (SSE, HTTP-streamable).

The following files were updated:
- `weather_mcp/main.py`: Modified to use 3333 as the default port if no port is specified via environment variables.
- `weather_mcp/run_server.sh`: Default port for the script updated to 3333.
- `weather_mcp/README.md`: All mentions of the default port 8000 were replaced with 3333, including examples and Docker configurations.
- `weather_mcp/config.yaml.example`: Added a `port: 3333` entry for clarity and future use, though the application does not currently read the port from this file.

This change standardizes the default port across the application and its documentation.